### PR TITLE
Add option for using colorgcc in chain

### DIFF
--- a/colorgcc.pl
+++ b/colorgcc.pl
@@ -121,7 +121,6 @@ my($unfinishedQuote, $previousColor);
 sub initDefaults
 {
   $nocolor{"dumb"} = "true";
-  $compilerPaths{"gcc"} = "/usr/bin/gcc";
 
   $colors{"srcColor"}             = color("bold white");
   $colors{"identColor"}           = color("bold green"); 

--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -32,6 +32,12 @@ color-gcc: /usr/bin/gcc
 color-c++: /usr/bin/c++
 color-cc:  /usr/bin/cc
 
+# Uncomment this if you want set up default path to gcc
+#g++: /usr/bin/g++
+#gcc: /usr/bin/gcc
+#c++: /usr/bin/c++
+#cc:  /usr/bin/cc
+
 # Don't do color if our terminal type ($TERM) is one of these.
 # (List all terminal types on one line, seperated by whitespace.)
 nocolor: dumb

--- a/colorgccrc.txt
+++ b/colorgccrc.txt
@@ -20,6 +20,10 @@
 # For example, srcColor: bold cyan on_yellow
 #
 
+# If you are using colorgcc in chain with other tools
+# e.g. ccache, uncomment this:
+chainedPath: 1
+
 # Only define the paths to the actual location of the various compilers 
 # if you need to do something weird.  For normal installs, 
 # we'll figure out who to call next automatically based on $PATH. 


### PR DESCRIPTION
This patch adds an ability for colorgcc to be used in chain with other tools (e.g. ccache) with determining of compiler's path relying only on the PATH env. variable.
This could be sufficient when the one uses automatic compilation or packaging tools.
It also solves Archlinux [bug #41423](https://bugs.archlinux.org/task/41423)
